### PR TITLE
Build

### DIFF
--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -159,7 +159,7 @@
 }
 
 .card__media .media img {
-  height: 100%;
+  height: 200px;
   object-fit: cover;
   object-position: center center;
   width: 100%;
@@ -244,6 +244,12 @@
 .card__heading a:focus {
   box-shadow: none;
   outline: 0;
+}
+
+/* Temp Fix */
+
+.product-card-wrapper .card__inner {
+  --ratio-percent: 100% !important;
 }
 
 @media screen and (min-width: 990px) {

--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -527,7 +527,10 @@
   "tag": "section",
   "class": "section section-featured-product",
   "disabled_on": {
-    "groups": ["header", "footer"]
+    "groups": [
+      "header",
+      "footer"
+    ]
   },
   "blocks": [
     {

--- a/templates/collection.json
+++ b/templates/collection.json
@@ -19,7 +19,7 @@
         "show_rating": false,
         "enable_filtering": true,
         "enable_sorting": true,
-        "columns_mobile": "2",
+        "columns_mobile": "1",
         "padding_top": 36,
         "padding_bottom": 36
       }


### PR DESCRIPTION
### PR Summary: 

Image size is constrained so each card is a similar size.

column size for mobile changed to 1

json format updated


### Why are these changes introduced?

So the pages look uniform and product cards look the same regardless of image size.

On mobile the products are large and the user is able to see everything in full.